### PR TITLE
Fixes and improvements to inclusion of related records and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,11 @@ An implementation of the [JSON API](http://jsonapi.org/) specification for Larav
 
         $ php artisan vendor:publish
 
-## JsonApiController
+## Usage
 
 The main class in this package is `JsonApiController`, which provides a full set of create, read, update and delete actions for a given Eloquent Model. A bunch of query parameters are supported which will affect the JSON API Objects returned, and you can also fetch and update model relationships.
 
-### Basic usage
-
-#### 1. Define routes
+### 1. Define routes
 
 Add a [RESTful resource route](https://laravel.com/docs/5.2/controllers#restful-resource-controllers) for the target model in `routes.php`.
 
@@ -47,7 +45,7 @@ Route::resource('users', 'UserController', [
 ]);
 ```
 
-#### 2. Add controller
+### 2. Add controller
 
 Our new controller for this resource needs to extend `JsonApiController` and use the `JsonApiControllerActions` trait. The base information to provide is the type of `Model` this controller is for, by implementing the abstract method `getModel`.
 
@@ -90,7 +88,35 @@ This package uses these Eloquent features heavily – the examples demonstrate f
 
 Coming soon.
 
-## Errors
+## Resource options
+
+### Inclusion of related resources
+
+To allow [including related resources](http://jsonapi.org/format/#fetching-includes) on a given resource, the model for the primary resource should implement the `IncludesRelatedResources` interface, providing a whitelist of relationship paths that can be included.
+
+```php
+namespace App\Http\Requests\User;
+
+use Huntie\JsonApi\Contracts\Model\IncludesRelatedResources;
+
+class Post extends Model implements IncludesRelatedResources
+{
+    /**
+     * The relationships which can be included with this resource.
+     *
+     * @return array
+     */
+    public function getIncludableRelations()
+    {
+        return [
+            'author',
+            'author.profile',
+        ];
+    }
+}
+```
+
+## Error handling
 
 There are a number of contexts where you may return error responses as formatted JSON API Error Objects.
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "illuminate/http": ">=5.2.0",
         "illuminate/pagination": ">=5.2.0",
         "illuminate/routing": ">=5.2.0",
-        "illuminate/support": ">=5.2.0"
+        "illuminate/support": ">=5.2.0",
+        "illuminate/validation": ">=5.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0.0",

--- a/config/jsonapi.php
+++ b/config/jsonapi.php
@@ -23,7 +23,9 @@ return [
     |
     | Set whether index and show endpoints for resources should support
     | including related records when the 'included' parameter is sent in a
-    | request.
+    | request. A whitelist of enabled relations can be set per-model by
+    | returning an array from getIncludableRelations when implementing
+    | JsonApiResource.
     |
     | http://jsonapi.org/format/#fetching-includes
     |

--- a/config/jsonapi.php
+++ b/config/jsonapi.php
@@ -24,8 +24,7 @@ return [
     | Set whether index and show endpoints for resources should support
     | including related records when the 'included' parameter is sent in a
     | request. A whitelist of enabled relations can be set per-model by
-    | returning an array from getIncludableRelations when implementing
-    | JsonApiResource.
+    | implementing \Huntie\JsonApi\Contracts\Model\IncludesRelatedResources.
     |
     | http://jsonapi.org/format/#fetching-includes
     |

--- a/config/jsonapi.php
+++ b/config/jsonapi.php
@@ -16,4 +16,19 @@ return [
 
     'include_version' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Enable inclusion of related resources
+    |--------------------------------------------------------------------------
+    |
+    | Set whether index and show endpoints for resources should support
+    | including related records when the 'included' parameter is sent in a
+    | request.
+    |
+    | http://jsonapi.org/format/#fetching-includes
+    |
+    */
+
+    'enable_included_resources' => true,
+
 ];

--- a/src/Contracts/JsonApiResource.php
+++ b/src/Contracts/JsonApiResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Huntie\JsonApi\Contracts;
+
+interface JsonApiResource
+{
+    /**
+     * The relationships which can be included with this resource.
+     *
+     * @return array
+     */
+    public function getIncludableRelations();
+}

--- a/src/Contracts/Model/IncludesRelatedResources.php
+++ b/src/Contracts/Model/IncludesRelatedResources.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Huntie\JsonApi\Contracts;
+namespace Huntie\JsonApi\Contracts\Model;
 
-interface JsonApiResource
+interface IncludesRelatedResources
 {
     /**
      * The relationships which can be included with this resource.

--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Huntie\JsonApi\Exceptions;
+
+use Huntie\JsonApi\Support\JsonApiErrors;
+use Illuminate\Http\Response;
+use Illuminate\Http\Exception\HttpResponseException;
+
+class HttpException extends HttpResponseException
+{
+    use JsonApiErrors;
+
+    /**
+     * Create a new HttpException instance.
+     *
+     * @param string            $message  The message for this exception
+     * @param Response|int|null $response The response object or HTTP status code send to the client
+     */
+    public function __construct($message, $response = null)
+    {
+        if (is_null($response)) {
+            $response = $this->error(Response::HTTP_BAD_REQUEST, $message);
+        } else if (is_int($response)) {
+            $response = $this->error($response, $message);
+        }
+
+        parent::__construct($response);
+    }
+}

--- a/src/Exceptions/InvalidRelationPathException.php
+++ b/src/Exceptions/InvalidRelationPathException.php
@@ -2,21 +2,20 @@
 
 namespace Huntie\JsonApi\Exceptions;
 
-use Exception;
+use Illuminate\Http\Response;
 
-class InvalidRelationPathException extends Exception
+class InvalidRelationPathException extends HttpException
 {
     /**
      * Create a new InvalidRelationPathException instance.
      *
-     * @param string         $path     The relation path attempted
-     * @param int|null       $code     User defined exception code
-     * @param Exception|null $previous Previous exception if nested
+     * @param string $path The relation path attempted
      */
-    public function __construct($path, $code = 0, Exception $previous = null)
+    public function __construct($path, $response = null)
     {
-        $message = sprintf('The relationship path "%s" could not be resolved', $path);
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct(
+            sprintf('The relationship path "%s" could not be resolved', $path),
+            Response::HTTP_BAD_REQUEST
+        );
     }
 }

--- a/src/Exceptions/InvalidRelationPathException.php
+++ b/src/Exceptions/InvalidRelationPathException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Huntie\JsonApi\Exceptions;
+
+use Exception;
+
+class InvalidRelationPathException extends Exception
+{
+    /**
+     * Create a new InvalidRelationPathException instance.
+     *
+     * @param string         $path     The relation path attempted
+     * @param int|null       $code     User defined exception code
+     * @param Exception|null $previous Previous exception if nested
+     */
+    public function __construct($path, $code = 0, Exception $previous = null)
+    {
+        $message = sprintf('The relationship path "%s" could not be resolved', $path);
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Http/Controllers/JsonApiController.php
+++ b/src/Http/Controllers/JsonApiController.php
@@ -4,6 +4,7 @@ namespace Huntie\JsonApi\Http\Controllers;
 
 use Schema;
 use Validator;
+use Huntie\JsonApi\Exceptions\HttpException;
 use Huntie\JsonApi\Http\JsonApiResponse;
 use Huntie\JsonApi\Serializers\CollectionSerializer;
 use Huntie\JsonApi\Serializers\RelationshipSerializer;
@@ -262,6 +263,12 @@ abstract class JsonApiController extends Controller
      */
     protected function getRequestParameters($request)
     {
+        $enableIncluded = config('jsonapi.enable_included_resources');
+
+        if ($request->has('include') && is_bool($enableIncluded) && !$enableIncluded) {
+            throw new HttpException('Inclusion of related resources is not supported');
+        }
+
         return [
             'fields' => $this->getRequestQuerySet($request, 'fields', '/^([A-Za-z]+.?)+[A-Za-z]+$/'),
             'include' => $this->getRequestQuerySet($request, 'include', '/^([A-Za-z]+.?)+[A-Za-z]+$/'),

--- a/src/Serializers/CollectionSerializer.php
+++ b/src/Serializers/CollectionSerializer.php
@@ -66,6 +66,8 @@ class CollectionSerializer extends JsonApiSerializer
      * Return a collection of JSON API resource objects for each included
      * relationship.
      *
+     * @throws \Huntie\JsonApi\Exceptions\InvalidRelationPathException
+     *
      * @return \Illuminate\Support\Collection
      */
     public function getIncludedRecords()

--- a/src/Serializers/RelationshipSerializer.php
+++ b/src/Serializers/RelationshipSerializer.php
@@ -2,8 +2,7 @@
 
 namespace Huntie\JsonApi\Serializers;
 
-use Exception;
-use Huntie\JsonApi\Exceptions\InvalidRelationPathException;
+use Huntie\JsonApi\Support\RelationshipIterator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
@@ -36,16 +35,7 @@ class RelationshipSerializer extends JsonApiSerializer
     {
         parent::__construct();
 
-        try {
-            $this->relation = $record;
-
-            foreach (explode('.', $path) as $relation) {
-                $this->relation = $this->relation->{$relation};
-            }
-        } catch (Exception $e) {
-            throw new InvalidRelationPathException($path);
-        }
-
+        $this->relation = (new RelationshipIterator($record, $path))->resolve();
         $this->fields = array_unique($fields);
     }
 

--- a/src/Serializers/RelationshipSerializer.php
+++ b/src/Serializers/RelationshipSerializer.php
@@ -2,6 +2,8 @@
 
 namespace Huntie\JsonApi\Serializers;
 
+use Exception;
+use Huntie\JsonApi\Exceptions\InvalidRelationPathException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
@@ -24,15 +26,26 @@ class RelationshipSerializer extends JsonApiSerializer
     /**
      * Create a new JSON API relationship serializer.
      *
-     * @param Model      $record   The primary record
-     * @param string     $relation The named relation to serialize
-     * @param array|null $fields   Subset of fields to return by record type
+     * @param Model      $record The primary record
+     * @param string     $path   The path to the relation to serialize
+     * @param array|null $fields Subset of fields to return by record type
+     *
+     * @throws InvalidRelationPathException
      */
-    public function __construct($record, $relation, array $fields = [])
+    public function __construct($record, $path, array $fields = [])
     {
         parent::__construct();
 
-        $this->relation = $record->{$relation};
+        try {
+            $this->relation = $record;
+
+            foreach (explode('.', $path) as $relation) {
+                $this->relation = $this->relation->{$relation};
+            }
+        } catch (Exception $e) {
+            throw new InvalidRelationPathException($path);
+        }
+
         $this->fields = array_unique($fields);
     }
 

--- a/src/Serializers/ResourceSerializer.php
+++ b/src/Serializers/ResourceSerializer.php
@@ -103,6 +103,8 @@ class ResourceSerializer extends JsonApiSerializer
      * Return a collection of JSON API resource objects for each included
      * relationship.
      *
+     * @throws \Huntie\JsonApi\Exceptions\InvalidRelationPathException
+     *
      * @return \Illuminate\Support\Collection
      */
     public function getIncludedRecords()
@@ -168,12 +170,12 @@ class ResourceSerializer extends JsonApiSerializer
      * Return a collection of JSON API resource identifier objects by each
      * relation on the primary record.
      *
+     * @throws \Huntie\JsonApi\Exceptions\InvalidRelationPathException
+     *
      * @return \Illuminate\Support\Collection
      */
     protected function transformRecordRelations()
     {
-        $this->record->load($this->relationships);
-
         return collect($this->relationships)->combine(array_map(function ($relation) {
             return [
                 'data' => (new RelationshipSerializer($this->record, $relation))->toResourceLinkage(),

--- a/src/Serializers/ResourceSerializer.php
+++ b/src/Serializers/ResourceSerializer.php
@@ -46,7 +46,7 @@ class ResourceSerializer extends JsonApiSerializer
         parent::__construct();
 
         $this->record = $record;
-        $this->relationships = array_merge($record->getRelations(), $include);
+        $this->relationships = array_merge(array_keys($record->getRelations()), $include);
         $this->fields = array_unique($fields);
         $this->include = array_unique($include);
     }

--- a/src/Support/RelationshipIterator.php
+++ b/src/Support/RelationshipIterator.php
@@ -3,6 +3,7 @@
 namespace Huntie\JsonApi\Support;
 
 use InvalidArgumentException;
+use Huntie\JsonApi\Contracts\JsonApiResource;
 use Huntie\JsonApi\Exceptions\InvalidRelationPathException;
 use Illuminate\Database\Eloquent\Model;
 
@@ -32,6 +33,10 @@ class RelationshipIterator
     {
         if (!preg_match('/^([A-Za-z]+.?)+[A-Za-z]+$/', $path)) {
             throw new InvalidArgumentException('The relationship path must be a valid string');
+        }
+
+        if (!$record instanceof JsonApiResource || !in_array($path, $record->getIncludableRelations())) {
+            throw new InvalidRelationPathException($path);
         }
 
         $this->record = $record;

--- a/src/Support/RelationshipIterator.php
+++ b/src/Support/RelationshipIterator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Huntie\JsonApi\Support;
+
+use InvalidArgumentException;
+use Huntie\JsonApi\Exceptions\InvalidRelationPathException;
+use Illuminate\Database\Eloquent\Model;
+
+class RelationshipIterator
+{
+    /**
+     * The primary record.
+     */
+    private $record;
+
+    /**
+     * The path to the relation.
+     *
+     * @var string
+     */
+    private $path;
+
+    /**
+     * Create a new RelationshipIterator instance.
+     *
+     * @param Model  $record The primary record
+     * @param string $path   The path to the relation
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($record, $path)
+    {
+        if (!preg_match('/^([A-Za-z]+.?)+[A-Za-z]+$/', $path)) {
+            throw new InvalidArgumentException('The relationship path must be a valid string');
+        }
+
+        $this->record = $record;
+        $this->path = $path;
+    }
+
+    /**
+     * Resolve the relationship from the primary record.
+     *
+     * @throws InvalidRelationPathException
+     *
+     * @return Collection|Model|null
+     */
+    public function resolve()
+    {
+        return array_reduce(explode('.', $this->path), function ($resolved, $relation) {
+            if (!$resolved instanceof Model || in_array($relation, $resolved->getHidden())) {
+                throw new InvalidRelationPathException($this->path);
+            }
+
+            return $resolved->{$relation};
+        }, $this->record);
+    }
+}

--- a/src/Support/RelationshipIterator.php
+++ b/src/Support/RelationshipIterator.php
@@ -3,7 +3,6 @@
 namespace Huntie\JsonApi\Support;
 
 use InvalidArgumentException;
-use Huntie\JsonApi\Contracts\JsonApiResource;
 use Huntie\JsonApi\Exceptions\InvalidRelationPathException;
 use Illuminate\Database\Eloquent\Model;
 
@@ -35,10 +34,6 @@ class RelationshipIterator
             throw new InvalidArgumentException('The relationship path must be a valid string');
         }
 
-        if (!$record instanceof JsonApiResource || !in_array($path, $record->getIncludableRelations())) {
-            throw new InvalidRelationPathException($path);
-        }
-
         $this->record = $record;
         $this->path = $path;
     }
@@ -48,7 +43,7 @@ class RelationshipIterator
      *
      * @throws InvalidRelationPathException
      *
-     * @return Collection|Model|null
+     * @return \Illuminate\Support\Collection|Model|null
      */
     public function resolve()
     {

--- a/tests/Fixtures/Models/Post.php
+++ b/tests/Fixtures/Models/Post.php
@@ -2,8 +2,24 @@
 
 namespace Huntie\JsonApi\Tests\Fixtures\Models;
 
-class Post extends Model
+use Huntie\JsonApi\Contracts\JsonApiResource;
+
+class Post extends Model implements JsonApiResource
 {
+    /**
+     * The relationships which can be included with this resource.
+     *
+     * @return array
+     */
+    public function getIncludableRelations()
+    {
+        return [
+            'author',
+            'comments',
+            'tags',
+        ];
+    }
+
     /**
      * The author of the post.
      *

--- a/tests/Fixtures/Models/Post.php
+++ b/tests/Fixtures/Models/Post.php
@@ -2,9 +2,9 @@
 
 namespace Huntie\JsonApi\Tests\Fixtures\Models;
 
-use Huntie\JsonApi\Contracts\JsonApiResource;
+use Huntie\JsonApi\Contracts\Model\IncludesRelatedResources;
 
-class Post extends Model implements JsonApiResource
+class Post extends Model implements IncludesRelatedResources
 {
     /**
      * The relationships which can be included with this resource.

--- a/tests/Fixtures/Models/User.php
+++ b/tests/Fixtures/Models/User.php
@@ -2,9 +2,9 @@
 
 namespace Huntie\JsonApi\Tests\Fixtures\Models;
 
-use Huntie\JsonApi\Contracts\JsonApiResource;
+use Huntie\JsonApi\Contracts\Model\IncludesRelatedResources;
 
-class User extends Model implements JsonApiResource
+class User extends Model implements IncludesRelatedResources
 {
     /**
      * The attributes excluded from the model's JSON form.

--- a/tests/Fixtures/Models/User.php
+++ b/tests/Fixtures/Models/User.php
@@ -2,7 +2,9 @@
 
 namespace Huntie\JsonApi\Tests\Fixtures\Models;
 
-class User extends Model
+use Huntie\JsonApi\Contracts\JsonApiResource;
+
+class User extends Model implements JsonApiResource
 {
     /**
      * The attributes excluded from the model's JSON form.
@@ -10,6 +12,19 @@ class User extends Model
      * @var array
      */
     protected $hidden = ['password'];
+
+    /**
+     * The relationships which can be included with this resource.
+     *
+     * @return array
+     */
+    public function getIncludableRelations()
+    {
+        return [
+            'posts',
+            'comments',
+        ];
+    }
 
     /**
      * The posts the user has authored.

--- a/tests/Serializers/RelationshipSerializerTest.php
+++ b/tests/Serializers/RelationshipSerializerTest.php
@@ -96,4 +96,19 @@ class RelationshipSerializerTest extends TestCase
             $this->assertArrayNotHasKey('content', $record['attributes']);
         }
     }
+
+    /**
+     * Test resolving an invalid relation path.
+     *
+     * @expectedException \Huntie\JsonApi\Exceptions\InvalidRelationPathException
+     */
+    public function testInvalidRelationPath()
+    {
+        $user = factory(User::class)
+            ->states('withPosts')
+            ->make();
+
+        $serializer = new RelationshipSerializer($user, 'nonexistent.relation');
+        $serializer->toResourceLinkage();
+    }
 }


### PR DESCRIPTION
- Add support for nested relationship serialisation
- The 'include' parameter is now correctly validated
- Support for inclusion of related resources can now be globally disabled
- Includable relations for a resource must now be whitelisted per-model by implementing IncludesRelatedResources
- Create base HttpException class to handle custom error responses (to be extended publicly and documented later)