### PR TITLE
Fix compatibility with Laravel 5.4.x

### DIFF
--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -3,8 +3,15 @@
 namespace Huntie\JsonApi\Exceptions;
 
 use Huntie\JsonApi\Support\JsonApiErrors;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Response;
-use Illuminate\Http\Exception\HttpResponseException;
+
+class_alias(
+    version_compare(Application::VERSION, '5.4.0', '>=') ?
+        'Illuminate\Http\Exceptions\HttpResponseException' :
+        'Illuminate\Http\Exception\HttpResponseException',
+    __NAMESPACE__ . '\HttpResponseException'
+);
 
 class HttpException extends HttpResponseException
 {

--- a/tests/Serializers/CollectionSerializerTest.php
+++ b/tests/Serializers/CollectionSerializerTest.php
@@ -17,7 +17,7 @@ class CollectionSerializerTest extends TestCase
     {
         $serializer = new CollectionSerializer(factory(User::class, 5)->make());
 
-        $this->seeJsonApiObjectCollection($serializer->serializeToObject(), 5);
+        $this->assertJsonApiObjectCollection($serializer->serializeToObject(), 5);
     }
 
     /**
@@ -59,7 +59,7 @@ class CollectionSerializerTest extends TestCase
         $included = $serializer->getIncludedRecords();
 
         $this->assertInstanceOf(Collection::class, $included);
-        $this->seeJsonApiObjectCollection(['data' => $included->toArray()], 6);
+        $this->assertJsonApiObjectCollection(['data' => $included->toArray()], 6);
 
         foreach ($included as $record) {
             $this->assertEquals('posts', $record['type'], 'Unexpected record type included with collection');

--- a/tests/Serializers/JsonApiSerializerTest.php
+++ b/tests/Serializers/JsonApiSerializerTest.php
@@ -17,7 +17,7 @@ class JsonApiSerializerTest extends TestCase
         $document = $serializer->serializeToObject();
 
         $this->assertInternalType('array', $document);
-        $this->seeJsonApiResourceObject($document);
+        $this->assertJsonApiResourceObject($document);
     }
 
     /**

--- a/tests/Serializers/RelationshipSerializerTest.php
+++ b/tests/Serializers/RelationshipSerializerTest.php
@@ -20,7 +20,7 @@ class RelationshipSerializerTest extends TestCase
         $serializer = new RelationshipSerializer($post, 'author');
         $relationship = $serializer->toResourceLinkage();
 
-        $this->seeJsonApiResourceIdentifier(['data' => $relationship]);
+        $this->assertJsonApiResourceIdentifier(['data' => $relationship]);
         $this->assertEquals([
             'type' => 'users',
             'id' => $post->author->id,
@@ -38,7 +38,7 @@ class RelationshipSerializerTest extends TestCase
         $serializer = new RelationshipSerializer($user, 'posts');
         $relationship = $serializer->toResourceLinkage();
 
-        $this->seeJsonApiIdentifierCollection(['data' => $relationship->toArray()], 2);
+        $this->assertJsonApiIdentifierCollection(['data' => $relationship->toArray()], 2);
 
         foreach ($relationship as $identifier) {
             $this->assertEquals('posts', $identifier['type']);
@@ -56,7 +56,7 @@ class RelationshipSerializerTest extends TestCase
         $serializer = new RelationshipSerializer($post, 'author');
         $relationship = $serializer->toResourceCollection();
 
-        $this->seeJsonApiResourceObject(['data' => $relationship]);
+        $this->assertJsonApiResourceObject(['data' => $relationship]);
         $this->assertEquals('users', $relationship['type']);
     }
 
@@ -71,7 +71,7 @@ class RelationshipSerializerTest extends TestCase
         $serializer = new RelationshipSerializer($user, 'posts');
         $relationship = $serializer->toResourceCollection();
 
-        $this->seeJsonApiObjectCollection(['data' => $relationship->toArray()], 2);
+        $this->assertJsonApiObjectCollection(['data' => $relationship->toArray()], 2);
 
         foreach ($relationship as $identifier) {
             $this->assertEquals('posts', $identifier['type']);

--- a/tests/Serializers/ResourceSerializerTest.php
+++ b/tests/Serializers/ResourceSerializerTest.php
@@ -79,7 +79,7 @@ class ResourceSerializerTest extends TestCase
 
         $this->assertArrayHasKey('relationships', $resource);
         $this->assertArrayHasKey('author', $resource['relationships']);
-        $this->seeJsonApiResourceIdentifier($resource['relationships']['author']);
+        $this->assertJsonApiResourceIdentifier($resource['relationships']['author']);
         $this->assertEquals('users', $resource['relationships']['author']['data']['type']);
         $this->assertArrayHasKey('comments', $resource['relationships']);
         $this->assertCount(2, $resource['relationships']['comments']['data']);
@@ -97,7 +97,7 @@ class ResourceSerializerTest extends TestCase
         $included = $serializer->getIncludedRecords();
 
         $this->assertInstanceOf(Collection::class, $included);
-        $this->seeJsonApiObjectCollection(['data' => $included->toArray()], 4);
+        $this->assertJsonApiObjectCollection(['data' => $included->toArray()], 4);
 
         foreach ($included as $record) {
             $this->assertRegExp('/posts|comments/', $record['type'], 'Unexpected record type included with resource');
@@ -117,7 +117,7 @@ class ResourceSerializerTest extends TestCase
         $included = $serializer->getIncludedRecords();
 
         $this->assertInstanceOf(Collection::class, $included);
-        $this->seeJsonApiObjectCollection(['data' => $included->toArray()], 2);
+        $this->assertCount(2, $included->toArray());
 
         foreach ($included as $record) {
             $this->assertEquals('posts', $record['type'], 'scopeIncludes() failed to return relationship subset');

--- a/tests/Support/JsonApiAssertions.php
+++ b/tests/Support/JsonApiAssertions.php
@@ -3,110 +3,88 @@
 namespace Huntie\JsonApi\Tests\Support;
 
 /**
- * Extend TestCase with additional JSON API assertions.
- *
- * @method seeJsonStructure
+ * Extend TestCase with additional JSON API related assertions.
  */
 trait JsonApiAssertions
 {
     /**
-     * Assert that a document containing a valid JSON API resource identifier
-     * object is returned.
+     * Assert that all given keys are set in an associative array. Nested
+     * members may be specified using dot notation.
      *
-     * @param array|null $responseData
+     * @param array $keys
+     * @param array $array
      *
-     * @return $this
+     * @throws PHPUnit_Framework_AssertionFailedError
      */
-    public function seeJsonApiResourceIdentifier($responseData = null)
+    public function assertArrayHasAll(array $keys, array $array)
     {
-        return $this->seeJsonStructure([
-            'data' => [
-                'type',
-                'id',
-            ]
-        ], $responseData);
+        foreach ($keys as $key) {
+            if (!array_has($array, $key)) {
+                $this->fail('Failed asserting that key "' . $key . '" exists in input array.');
+            }
+        }
     }
 
     /**
-     * Assert that a document containing a valid JSON API resource object is
-     * returned.
+     * Assert that an array contains a valid JSON API resource identifier.
      *
-     * @param array|null $responseData
+     * @param array $array
      *
-     * @return $this
+     * @throws PHPUnit_Framework_AssertionFailedError
      */
-    public function seeJsonApiResourceObject($responseData = null)
+    public function assertJsonApiResourceIdentifier(array $array)
     {
-        return $this->seeJsonStructure([
-            'data' => [
-                'type',
-                'id',
-                'attributes',
-            ]
-        ], $responseData);
+        $this->assertArrayHasAll(['data.type', 'data.id'], $array);
     }
 
     /**
-     * Assert that a document containing a valid JSON API resource identifier
-     * object collection is returned.
+     * Assert that an array contains a valid JSON API resource object.
      *
-     * @param array|null $responseData
-     * @param int|null   $count
+     * @param array $array
      *
-     * @return $this
+     * @throws PHPUnit_Framework_AssertionFailedError
      */
-    public function seeJsonApiIdentifierCollection($responseData = null, $count = null)
+    public function assertJsonApiResourceObject(array $array)
     {
-        return $this->seeJsonApiCollection([
-            'type',
-            'id',
-        ], $responseData, $count);
+        $this->assertArrayHasAll(['data.type', 'data.id', 'data.attributes'], $array);
     }
 
     /**
-     * Assert that a document containing a valid JSON API resource object
-     * collection is returned.
+     * Assert that an array contains a valid JSON API resource identifier
+     * object collection.
      *
-     * @param array|null $responseData
-     * @param int|null   $count
+     * @param array $array
+     * @param int   $count
      *
-     * @return $this
+     * @throws PHPUnit_Framework_AssertionFailedError
      */
-    public function seeJsonApiObjectCollection($responseData = null, $count = null)
+    public function assertJsonApiIdentifierCollection(array $array, $count = null)
     {
-        return $this->seeJsonApiCollection([
-            'type',
-            'id',
-            'attributes',
-        ], $responseData, $count);
-    }
+        $this->assertArrayHasKey('data', $array, 'No data key for collection');
 
-    /**
-     * Assert that a JSON API document contains a collection of objects defined
-     * by a given pattern.
-     *
-     * @param array      $pattern
-     * @param array|null $responseData
-     * @param int|null   $count
-     *
-     * @return $this
-     */
-    private function seeJsonApiCollection($pattern, $responseData = null, $count = null)
-    {
-        if (!$responseData) {
-            $responseData = json_decode($this->response->getContent(), true);
+        foreach ($array['data'] as $identifier) {
+            $this->assertArrayHasAll(['type', 'id'], (array) $identifier);
         }
 
-        $this->seeJsonStructure([
-            'data' => [
-                '*' => $pattern,
-            ]
-        ], $responseData);
+        $this->assertCount($count, $array['data'], 'Incorrect object count returned in collection');
+    }
 
-        if ($count) {
-            $this->assertCount($count, $responseData['data'], 'Incorrect object count returned in collection');
+    /**
+     * Assert that an array contains a valid JSON API resource object collection.
+     *
+     * @param array $array
+     * @param int   $count
+     *
+     * @throws PHPUnit_Framework_AssertionFailedError
+     */
+    public function assertJsonApiObjectCollection(array $array, $count = null)
+    {
+        $this->assertArrayHasKey('data', $array, 'No data key for collection');
+
+        foreach ($array['data'] as $object) {
+            $this->assertArrayHasAll(['type', 'id', 'attributes'], (array) $object);
         }
 
-        return $this;
+        $this->assertCount($count, $array['data'], 'Incorrect object count returned in collection');
     }
 }


### PR DESCRIPTION
- Fix reference to changed namespace for HttpResponseException
- Refactor extended test assertion methods to remove dependency on deprecated framework assertion helper