### PR TITLE
Test namespace refactoring, make helpers available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Huntie\\JsonApi\\Tests\\": "tests/"
+            "Tests\\": "tests/"
         }
     }
 }

--- a/src/Testing/JsonApiAssertions.php
+++ b/src/Testing/JsonApiAssertions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Support;
+namespace Huntie\JsonApi\Testing;
 
 /**
  * Extend TestCase with additional JSON API related assertions.

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Huntie\JsonApi\Tests\Fixtures\Controllers;
+
+use Huntie\JsonApi\Http\Controllers\JsonApiController;
+use Huntie\JsonApi\Http\Controllers\JsonApiControllerActions;
+use Huntie\JsonApi\Tests\Fixtures\Models\User;
+
+class UserController extends JsonApiController
+{
+    use JsonApiControllerActions;
+
+    /**
+     * Return the related Eloquent Model.
+     *
+     * @return Model
+     */
+    public function getModel()
+    {
+        return new User();
+    }
+}

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Controllers;
+namespace Tests\Fixtures\Controllers;
 
 use Huntie\JsonApi\Http\Controllers\JsonApiController;
 use Huntie\JsonApi\Http\Controllers\JsonApiControllerActions;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\Fixtures\Models\User;
 
 class UserController extends JsonApiController
 {

--- a/tests/Fixtures/Models/Comment.php
+++ b/tests/Fixtures/Models/Comment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Models;
+namespace Tests\Fixtures\Models;
 
 class Comment extends Model
 {

--- a/tests/Fixtures/Models/Model.php
+++ b/tests/Fixtures/Models/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Models;
+namespace Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 

--- a/tests/Fixtures/Models/Post.php
+++ b/tests/Fixtures/Models/Post.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Models;
+namespace Tests\Fixtures\Models;
 
 use Huntie\JsonApi\Contracts\Model\IncludesRelatedResources;
 

--- a/tests/Fixtures/Models/Tag.php
+++ b/tests/Fixtures/Models/Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Models;
+namespace Tests\Fixtures\Models;
 
 class Tag extends Model
 {

--- a/tests/Fixtures/Models/User.php
+++ b/tests/Fixtures/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Models;
+namespace Tests\Fixtures\Models;
 
 use Huntie\JsonApi\Contracts\Model\IncludesRelatedResources;
 

--- a/tests/Fixtures/Routes/ExampleRoutes.php
+++ b/tests/Fixtures/Routes/ExampleRoutes.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Fixtures\Routes;
+namespace Tests\Fixtures\Routes;
 
-use Huntie\JsonApi\Tests\Fixtures\Controllers\UserController;
+use Tests\Fixtures\Controllers\UserController;
 
 /**
  * Define example application routes for testing.

--- a/tests/Fixtures/Routes/ExampleRoutes.php
+++ b/tests/Fixtures/Routes/ExampleRoutes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Huntie\JsonApi\Tests\Fixtures\Routes;
+
+use Huntie\JsonApi\Tests\Fixtures\Controllers\UserController;
+
+/**
+ * Define example application routes for testing.
+ */
+trait ExampleRoutes
+{
+    /**
+     * Define environment setup.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    public function getEnvironmentSetup($app)
+    {
+        $app['router']->resource('users', UserController::class);
+    }
+}

--- a/tests/Serializers/CollectionSerializerTest.php
+++ b/tests/Serializers/CollectionSerializerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Serializers;
+namespace Tests\Serializers;
 
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Huntie\JsonApi\Serializers\CollectionSerializer;
-use Huntie\JsonApi\Tests\TestCase;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\TestCase;
+use Tests\Fixtures\Models\User;
 
 class CollectionSerializerTest extends TestCase
 {

--- a/tests/Serializers/JsonApiSerializerTest.php
+++ b/tests/Serializers/JsonApiSerializerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Serializers;
+namespace Tests\Serializers;
 
 use Huntie\JsonApi\Serializers\ResourceSerializer;
-use Huntie\JsonApi\Tests\TestCase;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\TestCase;
+use Tests\Fixtures\Models\User;
 
 class JsonApiSerializerTest extends TestCase
 {

--- a/tests/Serializers/RelationshipSerializerTest.php
+++ b/tests/Serializers/RelationshipSerializerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Serializers;
+namespace Tests\Serializers;
 
 use Huntie\JsonApi\Serializers\RelationshipSerializer;
-use Huntie\JsonApi\Tests\TestCase;
-use Huntie\JsonApi\Tests\Fixtures\Models\Post;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\TestCase;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
 
 class RelationshipSerializerTest extends TestCase
 {

--- a/tests/Serializers/ResourceSerializerTest.php
+++ b/tests/Serializers/ResourceSerializerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Serializers;
+namespace Tests\Serializers;
 
 use Huntie\JsonApi\Serializers\ResourceSerializer;
-use Huntie\JsonApi\Tests\TestCase;
-use Huntie\JsonApi\Tests\Fixtures\Models\Post;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\TestCase;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
 use Illuminate\Support\Collection;
 
 class ResourceSerializerTest extends TestCase

--- a/tests/Support/Factories/CommentFactory.php
+++ b/tests/Support/Factories/CommentFactory.php
@@ -1,8 +1,8 @@
 <?php
 
 use Faker\Generator;
-use Huntie\JsonApi\Tests\Fixtures\Models\Comment;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\Fixtures\Models\Comment;
+use Tests\Fixtures\Models\User;
 
 $factory->define(Comment::class, function (Generator $faker) {
     return [

--- a/tests/Support/Factories/PostFactory.php
+++ b/tests/Support/Factories/PostFactory.php
@@ -1,9 +1,9 @@
 <?php
 
 use Faker\Generator;
-use Huntie\JsonApi\Tests\Fixtures\Models\Comment;
-use Huntie\JsonApi\Tests\Fixtures\Models\Post;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\Fixtures\Models\Comment;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
 
 $factory->define(Post::class, function (Generator $faker) {
     return [

--- a/tests/Support/Factories/UserFactory.php
+++ b/tests/Support/Factories/UserFactory.php
@@ -1,9 +1,9 @@
 <?php
 
 use Faker\Generator;
-use Huntie\JsonApi\Tests\Fixtures\Models\Comment;
-use Huntie\JsonApi\Tests\Fixtures\Models\Post;
-use Huntie\JsonApi\Tests\Fixtures\Models\User;
+use Tests\Fixtures\Models\Comment;
+use Tests\Fixtures\Models\Post;
+use Tests\Fixtures\Models\User;
 
 $factory->define(User::class, function (Generator $faker) {
     return [

--- a/tests/Support/JsonApiAssertions.php
+++ b/tests/Support/JsonApiAssertions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Huntie\JsonApi\Tests\Support;
+namespace Tests\Support;
 
 /**
  * Extend TestCase with additional JSON API related assertions.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Tests\Support\JsonApiAssertions;
+use Huntie\JsonApi\Testing\JsonApiAssertions;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Huntie\JsonApi\Tests;
+namespace Tests;
 
-use Huntie\JsonApi\Tests\Support\JsonApiAssertions;
+use Tests\Support\JsonApiAssertions;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {


### PR DESCRIPTION
- Rename local package tests namespace as `Tests`
- Make `JsonApiAssertions` helper class available in project source as `Huntie\JsonApi\Testing\JsonApiAssertions`