### PR TITLE
API changes and refactoring of JsonApiController

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The main class in this package is `JsonApiController`, which provides a full set
 
 ### 1. Define routes
 
-Add a [RESTful resource route](https://laravel.com/docs/5.2/controllers#restful-resource-controllers) for the target model in `routes.php`.
+Add a [RESTful resource route](https://laravel.com/docs/master/controllers#restful-resource-controllers) for the target model in `routes.php`.
 
 ```php
 Route::resource('users', 'UserController');
@@ -47,14 +47,13 @@ Route::resource('users', 'UserController', [
 
 ### 2. Add controller
 
-Our new controller for this resource needs to extend `JsonApiController` and use the `JsonApiControllerActions` trait. The base information to provide is the type of `Model` this controller is for, by implementing the abstract method `getModel`.
+Our new controller for this resource needs to extend `JsonApiController` and use the `JsonApiControllerActions` trait. The model for the primary resource is inferred by default from the controller name, but this can also be set on the `$model` property.
 
 ```php
 <?php
 
 namespace App\Http\Controllers;
 
-use App\User;
 use Huntie\JsonApi\Http\Controllers\JsonApiController;
 use Huntie\JsonApi\Http\Controllers\JsonApiControllerActions;
 
@@ -63,24 +62,21 @@ class UserController extends JsonApiController
     use JsonApiControllerActions;
 
     /**
-     * Return the related Eloquent Model.
+     * The related Eloquent Model.
      *
-     * @return Model
+     * @var Model|string
      */
-    protected function getModel()
-    {
-        return new User();
-    }
+    protected $model = 'App\User';
 }
 ```
 
-The trait `JsonApiControllerActions` is important. It defines each endpoint `index`, `store`, `show`, `update`, `destroy` at the class level and calls the relevant parent controller method, e.g. `indexAction`. This allows us to override particular controller actions, meaning we can specify additional parameters as well as a different type-hinted request class for [Form Request Validation](https://laravel.com/docs/5.2/validation#form-request-validation).
+The trait `JsonApiControllerActions` is important. It defines each endpoint `index`, `store`, `show`, `update`, `destroy` at the class level and calls the relevant parent controller method, e.g. `indexAction`. This allows us to override particular controller actions, meaning we can specify additional parameters as well as a different type-hinted request class for [Form Request Validation](https://laravel.com/docs/master/validation#form-request-validation).
 
 The controller now will respond to each endpoint for this resource where a route has been defined.
 
 #### Implicit model transformation
 
-Whenever a model is tranformed into a JSON API Object or Collection, the built-in properties and methods defined on your Eloquent Model, such as `$casts`, `$hidden`, and `$appends` will apply automatically, removing the need for separate model tranformation logic. See [the Laravel docs](https://laravel.com/docs/5.2/eloquent) for more information on what is available.
+Whenever a model is tranformed into a JSON API Object or Collection, the built-in properties and methods defined on your Eloquent Model, such as `$casts`, `$hidden`, and `$appends` will apply automatically, removing the need for separate model tranformation logic. See [the Laravel docs](https://laravel.com/docs/master/eloquent) for more information on what is available.
 
 This package uses these Eloquent features heavily – the examples demonstrate further how these are applied.
 
@@ -122,7 +118,7 @@ There are a number of contexts where you may return error responses as formatted
 
 ### Form validation
 
-Implementing a [Form Request validation class](https://laravel.com/docs/5.2/validation#form-request-validation) that extends `JsonApiRequest` will format any validation errors appropriately when a validation error occurs.
+Implementing a [Form Request validation class](https://laravel.com/docs/master/validation#form-request-validation) that extends `JsonApiRequest` will format any validation errors appropriately when a validation error occurs.
 
 ```php
 <?php

--- a/config/jsonapi.php
+++ b/config/jsonapi.php
@@ -4,6 +4,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Model namespace
+    |--------------------------------------------------------------------------
+    |
+    | The full namespace containing the application's models. Used when
+    | inferring the primary resource model in JsonApiController, which can
+    | also be set manually through the $model property. Defaults to the
+    | application namespace.
+    |
+    */
+
+    'model_namespace' => '',
+
+    /*
+    |--------------------------------------------------------------------------
     | Include JSON API version
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Concerns/QueriesResources.php
+++ b/src/Http/Concerns/QueriesResources.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Huntie\JsonApi\Http\Concerns;
+
+use Schema;
+
+trait QueriesResources
+{
+    /**
+     * Sort a resource query by one or more attributes.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array                                 $attributes
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function sortQuery($query, array $attributes)
+    {
+        foreach ($attributes as $expression) {
+            $direction = substr($expression, 0, 1) === '-' ? 'desc' : 'asc';
+            $column = preg_replace('/^\-/', '', $expression);
+            $query = $query->orderBy($column, $direction);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Filter a resource query by one or more attributes.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array                                 $attributes
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function filterQuery($query, array $attributes)
+    {
+        $searchableColumns = array_diff(
+            Schema::getColumnListing($query->getModel()->getTable()),
+            $query->getModel()->getHidden()
+        );
+
+        foreach (array_intersect_key($attributes, array_flip($searchableColumns)) as $column => $value) {
+            if (is_numeric($value)) {
+                // Exact numeric match
+                $query = $query->where($column, $value);
+            } else if (in_array(strtolower($value), ['true', 'false'])) {
+                // Boolean match
+                $query = $query->where($column, filter_var($value, FILTER_VALIDATE_BOOLEAN));
+            } else {
+                // Partial string match
+                $query = $query->where($column, 'LIKE', '%' . $value . '%');
+            }
+        }
+
+        return $query;
+    }
+}

--- a/src/Http/Concerns/UpdatesModelRelations.php
+++ b/src/Http/Concerns/UpdatesModelRelations.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Huntie\JsonApi\Http\Concerns;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+trait UpdatesModelRelations
+{
+    /**
+     * The model relationships that can be updated.
+     *
+     * @var array
+     */
+    protected $fillableRelations = [];
+
+    /**
+     * Determine whether the given named relation can be updated on the model.
+     *
+     * @param string $relation
+     */
+    protected function isFillableRelation($relation): bool
+    {
+        return array_key_exists($relation, $this->fillableRelations);
+    }
+
+    /**
+     * Update one or more relationships on a model instance from an array of
+     * named relationships and associated resource identifiers.
+     *
+     * http://jsonapi.org/format/#crud-updating-resource-relationships
+     *
+     * @param Model $record
+     * @param array $relationships
+     */
+    protected function updateResourceRelationships($record, array $relationships)
+    {
+        $relationships = array_intersect_key($relationships, array_flip($this->fillableRelations));
+
+        foreach ($relationships as $name => $relationship) {
+            $relation = $record->{$name}();
+
+            if ($relation instanceof BelongsTo) {
+                $record->{$name}()->associate(array_get($relationship, 'data.id'));
+                $record->save();
+            } else if ($relation instanceof BelongsToMany) {
+                $record->{$name}()->sync(array_pluck($relationship['data'], 'id'));
+            }
+        }
+    }
+}

--- a/src/Http/Concerns/UpdatesModelRelations.php
+++ b/src/Http/Concerns/UpdatesModelRelations.php
@@ -19,9 +19,77 @@ trait UpdatesModelRelations
      *
      * @param string $relation
      */
-    protected function isFillableRelation($relation): bool
+    protected function isFillableRelation(string $relation): bool
     {
         return array_key_exists($relation, $this->fillableRelations);
+    }
+
+    /**
+     * Determine the JSON API relation type for a named relation on the primary
+     * resource.
+     *
+     * @param string $relation
+     *
+     * @return string|void
+     */
+    protected function getRelationType(string $relation)
+    {
+        $relation = $this->model->{$name}();
+
+        if ($relation instanceof BelongsTo) {
+            return 'To-One';
+        } else if ($relation instanceof BelongsToMany) {
+            return 'To-Many';
+        }
+    }
+
+    /**
+     * Update a named many-to-one relationship association on a model instance.
+     *
+     * http://jsonapi.org/format/#crud-updating-to-one-relationships
+     *
+     * @param Model  $record
+     * @param string $relation
+     * @param array  $data
+     */
+    protected function updateToOneResourceRelationship($record, string $relation, array $data)
+    {
+        $record->{$relation}()->associate($data['id']);
+        $record->save();
+    }
+
+    /**
+     * Update named many-to-many relationship entries on a model instance.
+     *
+     * http://jsonapi.org/format/#crud-updating-to-many-relationships
+     *
+     * @param Model  $record
+     * @param string $relation
+     * @param array  $data
+     * @param string $method
+     */
+    protected function updateToManyResourceRelationship($record, string $relation, array $data, string $method)
+    {
+        $items = [];
+
+        foreach ($data as $item) {
+            if (isset($item['attributes'])) {
+                $items[$item['id']] = $item['attributes'];
+            } else {
+                $items[] = $item['id'];
+            }
+        }
+
+        switch ($method) {
+            case 'PATCH':
+                $record->{$relation}()->sync($items);
+                break;
+            case 'POST':
+                $record->{$relation}()->sync($items, false);
+                break;
+            case 'DELETE':
+                $record->{$relation}()->detach(array_keys($items));
+        }
     }
 
     /**
@@ -38,12 +106,10 @@ trait UpdatesModelRelations
         $relationships = array_intersect_key($relationships, array_flip($this->fillableRelations));
 
         foreach ($relationships as $name => $relationship) {
-            $relation = $record->{$name}();
-
-            if ($relation instanceof BelongsTo) {
+            if ($this->getRelationType($relation) === 'To-One') {
                 $record->{$name}()->associate(array_get($relationship, 'data.id'));
                 $record->save();
-            } else if ($relation instanceof BelongsToMany) {
+            } else if ($this->getRelationType($relation) === 'To-Many') {
                 $record->{$name}()->sync(array_pluck($relationship['data'], 'id'));
             }
         }

--- a/src/Http/Controllers/JsonApiController.php
+++ b/src/Http/Controllers/JsonApiController.php
@@ -163,7 +163,7 @@ abstract class JsonApiController extends Controller
      *
      * @return JsonApiResponse
      */
-    public function relationshipAction(Request $request, $record, $relation)
+    public function showRelationshipAction(Request $request, $record, $relation)
     {
         $record = $this->findModelInstance($record);
 

--- a/src/Http/Controllers/JsonApiControllerActions.php
+++ b/src/Http/Controllers/JsonApiControllerActions.php
@@ -7,12 +7,7 @@ use Illuminate\Http\Request;
 /**
  * Add default resource controller methods for JsonApiController actions.
  *
- * @method indexAction(Request $request)
- * @method storeAction(Request $request)
- * @method showAction(Request $request, int $id)
- * @method updateAction(Request $request, int $id)
- * @method destroyAction(Request $request, int $id)
- * @method relationshipAction(Request $request, int $id, string $relation)
+ * @return JsonApiController
  */
 trait JsonApiControllerActions
 {
@@ -88,8 +83,8 @@ trait JsonApiControllerActions
      *
      * @return \Huntie\JsonApi\Http\JsonApiResponse
      */
-    public function relationship(Request $request, $id, $relation)
+    public function showRelationship(Request $request, $id, $relation)
     {
-        return $this->relationshipAction($request, $id, $relation);
+        return $this->showRelationshipAction($request, $id, $relation);
     }
 }


### PR DESCRIPTION
- Add implicit model resolution to JsonApiController and replace getModel() with model property
- Rename controller `relationshipAction` as `showRelationshipAction`
- Consolidate relationship update controller methods into a single `updateRelationshipAction` method
- Partition controller responsibilities into separate traits

Breaking API changes included.