### PR TITLE
Allow count to be optional for assertJsonApiObjectCollection

### DIFF
--- a/src/Testing/JsonApiAssertions.php
+++ b/src/Testing/JsonApiAssertions.php
@@ -85,6 +85,8 @@ trait JsonApiAssertions
             $this->assertArrayHasAll(['type', 'id', 'attributes'], (array) $object);
         }
 
-        $this->assertCount($count, $array['data'], 'Incorrect object count returned in collection');
+        if (!is_null($count)) {
+            $this->assertCount($count, $array['data'], 'Incorrect object count returned in collection');
+        }
     }
 }


### PR DESCRIPTION
2nd argument of method shows count should be optional, but PHPUnit will through an exception on assertCount if null