### PR TITLE
Fix generated model relationships in unit tests

### DIFF
--- a/tests/Serializers/CollectionSerializerTest.php
+++ b/tests/Serializers/CollectionSerializerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Huntie\JsonApi\Serializers\CollectionSerializer;
 use Tests\TestCase;
+use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
 
 class CollectionSerializerTest extends TestCase
@@ -53,8 +54,13 @@ class CollectionSerializerTest extends TestCase
     public function testIncludedRecords()
     {
         $users = factory(User::class, 3)
-            ->states('withPosts')
-            ->make();
+            ->make()
+            ->map(function ($user) {
+                $user->posts = factory(Post::class, 2)->make();
+
+                return $user;
+            });
+
         $serializer = new CollectionSerializer($users, [], ['posts']);
         $included = $serializer->getIncludedRecords();
 

--- a/tests/Serializers/RelationshipSerializerTest.php
+++ b/tests/Serializers/RelationshipSerializerTest.php
@@ -14,9 +14,9 @@ class RelationshipSerializerTest extends TestCase
      */
     public function testHasOneToResourceLinkage()
     {
-        $post = factory(Post::class)
-            ->states('withAuthor')
-            ->make();
+        $post = factory(Post::class)->make();
+        $post->author = factory(User::class)->make();
+
         $serializer = new RelationshipSerializer($post, 'author');
         $relationship = $serializer->toResourceLinkage();
 
@@ -32,9 +32,9 @@ class RelationshipSerializerTest extends TestCase
      */
     public function testHasManyToResourceLinkage()
     {
-        $user = factory(User::class)
-            ->states('withPosts')
-            ->make();
+        $user = factory(User::class)->make();
+        $user->posts = factory(Post::class, 2)->make();
+
         $serializer = new RelationshipSerializer($user, 'posts');
         $relationship = $serializer->toResourceLinkage();
 
@@ -50,9 +50,9 @@ class RelationshipSerializerTest extends TestCase
      */
     public function testHasOneToResourceCollection()
     {
-        $post = factory(Post::class)
-            ->states('withAuthor')
-            ->make();
+        $post = factory(Post::class)->make();
+        $post->author = factory(User::class)->make();
+
         $serializer = new RelationshipSerializer($post, 'author');
         $relationship = $serializer->toResourceCollection();
 
@@ -65,9 +65,9 @@ class RelationshipSerializerTest extends TestCase
      */
     public function testHasManyToResourceCollection()
     {
-        $user = factory(User::class)
-            ->states('withPosts')
-            ->make();
+        $user = factory(User::class)->make();
+        $user->posts = factory(Post::class, 2)->make();
+
         $serializer = new RelationshipSerializer($user, 'posts');
         $relationship = $serializer->toResourceCollection();
 
@@ -83,9 +83,9 @@ class RelationshipSerializerTest extends TestCase
      */
     public function testCollectionFieldSubset()
     {
-        $user = factory(User::class)
-            ->states('withPosts')
-            ->make();
+        $user = factory(User::class)->make();
+        $user->posts = factory(Post::class, 2)->make();
+
         $serializer = new RelationshipSerializer($user, 'posts', [
             'posts' => ['title', 'created_at']
         ]);
@@ -104,9 +104,7 @@ class RelationshipSerializerTest extends TestCase
      */
     public function testInvalidRelationPath()
     {
-        $user = factory(User::class)
-            ->states('withPosts')
-            ->make();
+        $user = factory(User::class)->make();
 
         $serializer = new RelationshipSerializer($user, 'nonexistent.relation');
         $serializer->toResourceLinkage();

--- a/tests/Serializers/ResourceSerializerTest.php
+++ b/tests/Serializers/ResourceSerializerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Serializers;
 
 use Huntie\JsonApi\Serializers\ResourceSerializer;
 use Tests\TestCase;
+use Tests\Fixtures\Models\Comment;
 use Tests\Fixtures\Models\Post;
 use Tests\Fixtures\Models\User;
 use Illuminate\Support\Collection;
@@ -71,9 +72,10 @@ class ResourceSerializerTest extends TestCase
      */
     public function testResourceRelationships()
     {
-        $post = factory(Post::class)
-            ->states('withAuthor', 'withComments')
-            ->make();
+        $post = factory(Post::class)->make();
+        $post->author = factory(User::class)->make();
+        $post->comments = factory(Comment::class, 2)->make();
+
         $serializer = new ResourceSerializer($post, [],  ['author', 'comments']);
         $resource = $serializer->toResourceObject();
 
@@ -90,9 +92,10 @@ class ResourceSerializerTest extends TestCase
      */
     public function testIncludedRecords()
     {
-        $user = factory(User::class)
-            ->states('withPosts', 'withComments')
-            ->make();
+        $user = factory(User::class)->make();
+        $user->posts = factory(Post::class, 2)->make();
+        $user->comments = factory(Comment::class, 2)->make();
+
         $serializer = new ResourceSerializer($user, [], ['posts', 'comments']);
         $included = $serializer->getIncludedRecords();
 
@@ -109,9 +112,10 @@ class ResourceSerializerTest extends TestCase
      */
     public function testScopeIncludedRecords()
     {
-        $user = factory(User::class)
-            ->states('withPosts', 'withComments')
-            ->make();
+        $user = factory(User::class)->make();
+        $user->posts = factory(Post::class, 2)->make();
+        $user->comments = factory(Comment::class, 2)->make();
+
         $serializer = new ResourceSerializer($user, [], ['posts', 'comments']);
         $serializer->scopeIncludes(['posts']);
         $included = $serializer->getIncludedRecords();

--- a/tests/Support/Factories/PostFactory.php
+++ b/tests/Support/Factories/PostFactory.php
@@ -13,15 +13,3 @@ $factory->define(Post::class, function (Generator $faker) {
         'created_at' => $faker->dateTime(),
     ];
 });
-
-$factory->state(Post::class, 'withAuthor', function (Generator $faker) {
-    return [
-        'author' => factory(User::class)->make(),
-    ];
-});
-
-$factory->state(Post::class, 'withComments', function (Generator $faker) {
-    return [
-        'comments' => factory(Comment::class, 2)->make(),
-    ];
-});

--- a/tests/Support/Factories/UserFactory.php
+++ b/tests/Support/Factories/UserFactory.php
@@ -13,15 +13,3 @@ $factory->define(User::class, function (Generator $faker) {
         'password' => bcrypt('password'),
     ];
 });
-
-$factory->state(User::class, 'withPosts', function (Generator $faker) {
-    return [
-        'posts' => factory(Post::class, 2)->make(),
-    ];
-});
-
-$factory->state(User::class, 'withComments', function (Generator $faker) {
-    return [
-        'comments' => factory(Comment::class, 2)->make(),
-    ];
-});


### PR DESCRIPTION
In response to recent changes in the Laravel framework affecting assignment of Model instances through factories. This had broken integration checks since the last merge.