### PR TITLE
Extend Router with methods for JSON API resources

### DIFF
--- a/src/JsonApiServiceProvider.php
+++ b/src/JsonApiServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Huntie\JsonApi;
 
+use Huntie\JsonApi\Routing\ResourceRegistrar;
+use Huntie\JsonApi\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 
 class JsonApiServiceProvider extends ServiceProvider
@@ -11,7 +13,13 @@ class JsonApiServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->singleton('router', function ($app) {
+            return new Router($app['events'], $app);
+        });
+
+        $this->app->bind('Illuminate\Routing\ResourceRegistrar', function ($app) {
+            return new ResourceRegistrar($app['router']);
+        });
     }
 
     /**

--- a/src/JsonApiServiceProvider.php
+++ b/src/JsonApiServiceProvider.php
@@ -17,7 +17,7 @@ class JsonApiServiceProvider extends ServiceProvider
             return new Router($app['events'], $app);
         });
 
-        $this->app->bind('Illuminate\Routing\ResourceRegistrar', function ($app) {
+        $this->app->bind('Huntie\JsonApi\Routing\ResourceRegistrar', function ($app) {
             return new ResourceRegistrar($app['router']);
         });
     }

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -124,4 +124,26 @@ class ResourceRegistrar extends \Illuminate\Routing\ResourceRegistrar
     {
         return sprintf('%s/{%s}/relationships/{relationship}', $this->getResourceUri($name), $base);
     }
+
+    /**
+     * Format a resource parameter for usage.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public function getResourceWildcard($value)
+    {
+        if (isset($this->parameters[$value])) {
+            return $this->parameters[$value];
+        } else if (isset(static::$parameterMap[$value])) {
+            return static::$parameterMap[$value];
+        }
+
+        if ($this->parameters === 'singular' || static::$singularParameters) {
+            $value = str_singular($value);
+        }
+
+        return camel_case($value);
+    }
 }

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Huntie\JsonApi\Routing;
+
+class ResourceRegistrar extends \Illuminate\Routing\ResourceRegistrar
+{
+    /**
+     * The default actions for a resourceful controller.
+     *
+     * @var array
+     */
+    protected $resourceDefaults = ['index', 'store', 'show', 'update', 'destroy'];
+
+    /**
+     * Create a new resource registrar instance.
+     *
+     * @param \Huntie\JsonApi\Routing\Router $router
+     */
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+    }
+}

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -12,6 +12,13 @@ class ResourceRegistrar extends \Illuminate\Routing\ResourceRegistrar
     protected $resourceDefaults = ['index', 'store', 'show', 'update', 'destroy'];
 
     /**
+     * The default actions for each named resource relationship.
+     *
+     * @var array
+     */
+    protected $relationshipDefaults = ['show'];
+
+    /**
      * Create a new resource registrar instance.
      *
      * @param \Huntie\JsonApi\Routing\Router $router
@@ -19,5 +26,102 @@ class ResourceRegistrar extends \Illuminate\Routing\ResourceRegistrar
     public function __construct(Router $router)
     {
         $this->router = $router;
+    }
+
+    /**
+     * Route a resource to a controller.
+     *
+     * @param string $name
+     * @param string $controller
+     * @param array  $options
+     */
+    public function register($name, $controller, array $options = [])
+    {
+        parent::register($name, $controller, $options);
+
+        $this->registerRelationships($name, $controller, $options);
+    }
+
+    /**
+     * Route any resource relationships to a controller.
+     *
+     * @param string $name
+     * @param string $controller
+     * @param array  $options
+     */
+    protected function registerRelationships($name, $controller, array $options)
+    {
+        $base = $this->getResourceWildcard(last(explode('.', $name)));
+
+        // Map non-associative members as keys, with default relationship actions
+        $relationships = collect(array_get($options, 'relationships', []))
+            ->mapWithKeys(function ($methods, $relationship) {
+                return is_numeric($relationship)
+                    ? [$methods => $this->relationshipDefaults]
+                    : [$relationship => (array) $methods];
+            });
+
+        foreach (['show', 'update'] as $action) {
+            $matched = $relationships->filter(function ($methods) use ($action) {
+                return in_array($action, $methods);
+            })->keys()->toArray();
+
+            if (!empty($matched)) {
+                $this->{'addRelationship' . ucfirst($action)}($name, $base, $matched, $controller, $options);
+            }
+        }
+    }
+
+    /**
+     * Add a relationship show method to match named relationships on the resource.
+     *
+     * @param string $name
+     * @param string $base
+     * @param array  $relationships
+     * @param string $controller
+     * @param array  $options
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addRelationshipShow($name, $base, array $relationships, $controller, array $options)
+    {
+        $uri = $this->getRelationshipUri($name, $base);
+        $action = $this->getResourceAction($name, $controller, 'showRelationship', $options);
+
+        return $this->router->get($uri, $action)
+            ->where('relationship', '(' . implode(')|(', $relationships) . ')');
+    }
+
+    /**
+     * Add a relationship update method to match named relationships on the resource.
+     *
+     * @param string $name
+     * @param string $base
+     * @param array  $relationships
+     * @param string $controller
+     * @param array  $options
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addRelationshipUpdate($name, $base, array $relationships, $controller, array $options)
+    {
+        $uri = $this->getRelationshipUri($name, $base);
+        $action = $this->getResourceAction($name, $controller, 'updateRelationship', $options);
+
+        return $this->router->match(['PUT', 'PATCH'], $uri, $action)
+            ->where('relationship', '(' . implode(')|(', $relationships) . ')');
+    }
+
+    /**
+     * Get the URI for resource relationships.
+     *
+     * @param string $name
+     * @param string $base
+     *
+     * @return string
+     */
+    public function getRelationshipUri($name, $base)
+    {
+        return sprintf('%s/{%s}/relationships/{relationship}', $this->getResourceUri($name), $base);
     }
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -5,13 +5,13 @@ namespace Huntie\JsonApi\Routing;
 class Router extends \Illuminate\Routing\Router
 {
     /**
-     * Route a resource to a controller.
+     * Route a JSON API resource to a controller.
      *
      * @param string $name
      * @param string $controller
      * @param array  $options
      */
-    public function resource($name, $controller, array $options = [])
+    public function jsonApiResource($name, $controller, array $options = [])
     {
         if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
             $registrar = $this->container->make(ResourceRegistrar::class);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -5,6 +5,18 @@ namespace Huntie\JsonApi\Routing;
 class Router extends \Illuminate\Routing\Router
 {
     /**
+     * Register an array of JSON API resource controllers.
+     *
+     * @param array $resources
+     */
+    public function jsonApiResources(array $resources)
+    {
+        foreach ($resources as $name => $controller) {
+            $this->resource($name, $controller);
+        }
+    }
+
+    /**
      * Route a JSON API resource to a controller.
      *
      * @param string $name

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Huntie\JsonApi\Routing;
+
+class Router extends \Illuminate\Routing\Router
+{
+}

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -4,4 +4,21 @@ namespace Huntie\JsonApi\Routing;
 
 class Router extends \Illuminate\Routing\Router
 {
+    /**
+     * Route a resource to a controller.
+     *
+     * @param string $name
+     * @param string $controller
+     * @param array  $options
+     */
+    public function resource($name, $controller, array $options = [])
+    {
+        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
+            $registrar = $this->container->make(ResourceRegistrar::class);
+        } else {
+            $registrar = new ResourceRegistrar($this);
+        }
+
+        $registrar->register($name, $controller, $options);
+    }
 }


### PR DESCRIPTION
`Route::jsonApiResource()` provides better action defaults for API routes, and provides a `relationships` option for registering any relationship routes matching named relations. To document shortly!