### PR TITLE
Add support for including nested related resources through a has-many relationship

### DIFF
--- a/src/Support/RelationshipIterator.php
+++ b/src/Support/RelationshipIterator.php
@@ -60,13 +60,11 @@ class RelationshipIterator
      */
     private function iterate($resolved, $path)
     {
-        if (empty($path)) {
-            return $resolved;
-        }
-
         list($relation, $path) = array_pad(explode('.', $path, 2), 2, null);
 
-        $resolved = $resolved->{$relation};
+        if (empty($relation) || is_null($resolved = $resolved->{$relation})) {
+            return $resolved;
+        }
 
         if ($resolved instanceof Collection) {
             return $resolved->map(function ($record) use ($path) {

--- a/src/Support/RelationshipIterator.php
+++ b/src/Support/RelationshipIterator.php
@@ -64,8 +64,7 @@ class RelationshipIterator
             return $resolved;
         }
 
-        $relation = null;
-        [$relation, $path] = array_pad(explode('.', $path, 2), 2, null);
+        list($relation, $path) = array_pad(explode('.', $path, 2), 2, null);
 
         $resolved = $resolved->{$relation};
 

--- a/tests/Serializers/ResourceSerializerTest.php
+++ b/tests/Serializers/ResourceSerializerTest.php
@@ -96,14 +96,18 @@ class ResourceSerializerTest extends TestCase
         $user->posts = factory(Post::class, 2)->make();
         $user->comments = factory(Comment::class, 2)->make();
 
-        $serializer = new ResourceSerializer($user, [], ['posts', 'comments']);
+        foreach ($user->comments as $comment) {
+            $comment->creator = factory(User::class)->make();
+        }
+
+        $serializer = new ResourceSerializer($user, [], ['posts', 'comments', 'comments.creator']);
         $included = $serializer->getIncluded();
 
         $this->assertInstanceOf(Collection::class, $included);
-        $this->assertJsonApiObjectCollection(['data' => $included->toArray()], 4);
+        $this->assertJsonApiObjectCollection(['data' => $included->toArray()], 6);
 
         foreach ($included as $record) {
-            $this->assertRegExp('/posts|comments/', $record['type'], 'Unexpected record type included with resource');
+            $this->assertRegExp('/posts|comments|user/', $record['type'], 'Unexpected record type included with resource');
         }
     }
 


### PR DESCRIPTION
Previously, only relationship includes of the pattern `hasOne.hasMany` was supported. It is now possible to include `hasMany.hasOne` relationships in a resource response.